### PR TITLE
Enfapi terraform firewall config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.terraform
+src/github.com
+bin
+terraform-provider-enf
+pkg/darwin_amd64/enf.a
+crash.log
+terraform.tfstate
+terraform.tfstate.backup
+pkg

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+        "github.com/hashicorp/terraform/plugin"
+        "github.com/hashicorp/terraform/terraform"
+        "enf"
+)
+
+func main() {
+        plugin.Serve(&plugin.ServeOpts{
+                ProviderFunc: func() terraform.ResourceProvider {
+                        return enf.Provider()
+                },
+        })
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,15 @@
+provider "enf" {
+  username = "xap@admin"
+  password = "Test1234"
+}
+
+resource "enf_firewall" "ex" {
+  network   = "fd00:8f80:8000::/64"
+  ip_family = "IP6"
+
+  priority    = 1
+  protocol    = "TCP"
+  direction   = "EGRESS"
+  source_port = "22"
+  action      = "ACCEPT"
+}

--- a/src/enf/config.go
+++ b/src/enf/config.go
@@ -1,0 +1,79 @@
+package enf
+
+import (
+    "log"
+    "net/http"
+    "encoding/json"
+    "bytes"
+    "io/ioutil"
+)
+
+
+type Response struct {
+    Data []Data
+    Page Pages
+}
+
+type Data struct {
+    Username   string `json:"username"`
+    Token   string `json:"token"`
+    UserID    int    `json:"user_id"`
+    Type string `json:"type"`
+    DomainID int `json:"domain_id"`
+    DomainNetwork string `json:"domain_network"`
+}
+
+type Pages struct {
+    Curr int `json:"curr"`
+    Next int `json: "next"`
+    Prev int `json: "prev"` 
+}
+
+type Config struct {
+    Username string
+    Password string
+    DomainURL string 
+}
+
+type EnfClient struct {
+    ApiToken  string
+    DomainURL string
+    HTTPClient *http.Client
+}
+
+func (c *Config) Client() (interface{}, error) {
+
+
+        jsonData := map[string]string{"username": c.Username, "token": c.Password}
+        jsonValue, _ := json.Marshal(jsonData)
+
+        domain_url := "https://dev.xaptum.io"
+        url := domain_url + "/api/xcr/v2/xauth"
+        req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+
+        req.Header.Add("content-type", "application/json")
+        req.Header.Add("accept", "application/json")
+        http_client := http.Client{}
+        response, err := http_client.Do(req)
+
+
+        if err != nil {
+              log.Printf("The HTTP request failed with error %s\n", err)
+              return nil, err 
+        } else {
+                data_body, _ := ioutil.ReadAll(response.Body)
+
+                var resp Response
+                json.Unmarshal([]byte(data_body), &resp)
+                
+                client := &EnfClient{
+                    ApiToken: resp.Data[0].Token,
+                    DomainURL: domain_url,
+                    HTTPClient: &http_client,
+                }
+
+                return client, nil
+        }
+
+
+}

--- a/src/enf/provider.go
+++ b/src/enf/provider.go
@@ -1,0 +1,51 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+        "log"
+)
+
+
+
+func Provider() *schema.Provider {
+
+        return &schema.Provider{
+
+            Schema: map[string]*schema.Schema{
+                "username": {
+                    Type:        schema.TypeString,
+                    Optional:    true,
+                    DefaultFunc: schema.EnvDefaultFunc("ENF_USERNAME", nil),
+                    Description: "Username for authenticating with dev.xaptum.io",
+                },
+                "password": {
+                    Type:        schema.TypeString,
+                    Optional:    true,
+                    DefaultFunc: schema.EnvDefaultFunc("ENF_PASSWORD", nil),
+                    Description: "Password for authenticating with dev.xaptum.io",
+                },
+                "domain_url": {
+                    Type:        schema.TypeString,
+                    Optional:    true,
+                    DefaultFunc: schema.EnvDefaultFunc("ENF_DOMAIN_URL", nil),
+                    Description: "Base URL for API calls",
+                },
+            },
+
+                ConfigureFunc: providerConfigure,
+
+                ResourcesMap: map[string]*schema.Resource{
+                    },
+        }
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+
+    config := Config{
+        Username: d.Get("username").(string),
+        Password: d.Get("password").(string),
+        DomainURL: d.Get("domain_url").(string),
+
+    }
+    return config.Client()
+}

--- a/src/enf/resource_enf_connection.go
+++ b/src/enf/resource_enf_connection.go
@@ -1,0 +1,41 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfConnection() *schema.Resource {
+        return &schema.Resource{
+                Create: enfConnectionCreate,
+                Read:   enfConnectionRead,
+                Update: enfConnectionUpdate,
+                Delete: enfConnectionDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "ipv6": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                },
+        }
+}
+
+func enfConnectionCreate(d *schema.ResourceData, m interface{}) error {
+        ipv6 := d.Get("ipv6").(string)
+        d.SetId(ipv6)
+        return enfGroupRead(d, m)
+}
+
+func enfConnectionRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfConnectionUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfConnectionRead(d, m)
+}
+
+func enfConnectionDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+

--- a/src/enf/resource_enf_domain.go
+++ b/src/enf/resource_enf_domain.go
@@ -1,0 +1,49 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfDomain() *schema.Resource {
+        return &schema.Resource{
+                Create: enfDomainCreate,
+                Read:   enfDomainRead,
+                Update: enfDomainUpdate,
+                Delete: enfDomainDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "domain_id": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "domain_network": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "network_cidr": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                },
+        }
+}
+
+func enfDomainCreate(d *schema.ResourceData, m interface{}) error {
+        domain_id := d.Get("domain_id").(string)
+        d.SetId(domain_id)
+        return enfDomainRead(d, m)
+}
+
+func enfDomainRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfDomainUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfDomainRead(d, m)
+}
+
+func enfDomainDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+

--- a/src/enf/resource_enf_endpoint.go
+++ b/src/enf/resource_enf_endpoint.go
@@ -1,0 +1,41 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfEndpoint() *schema.Resource {
+        return &schema.Resource{
+                Create: enfEndpointCreate,
+                Read:   enfEndpointRead,
+                Update: enfEndpointUpdate,
+                Delete: enfEndpointDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "address": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                },
+        }
+}
+
+func enfEndpointCreate(d *schema.ResourceData, m interface{}) error {
+        address := d.Get("address").(string)
+        d.SetId(address)
+        return enfEndpointRead(d, m)
+}
+
+func enfEndpointRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfEndpointUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfEndpointRead(d, m)
+}
+
+func enfEndpointDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+

--- a/src/enf/resource_enf_firewall_rule.go
+++ b/src/enf/resource_enf_firewall_rule.go
@@ -1,0 +1,202 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+        "fmt"
+        "net/http"
+        "io/ioutil"
+        "encoding/json"
+        "bytes"
+        "log"
+
+)
+
+
+type firewallRule struct {
+    Id   string `json:"id"`
+    Priority   int `json:"priority"`
+    Protocol    string    `json:"protocol"`
+    Direction string `json:"direction"`
+    SourceIP string `json:"source_ip"`
+    SourcePort int `json:"source_port"`
+    DestIP string `json:"dest_ip"`
+    DestPort int `json:"dest_port"`
+    Ack string `json:"ack"`
+    Action string `json:"action"`
+    IPFamily string `json:"ip_family"`
+    Network string `json:"network"`
+}
+
+type firewallRuleCreate struct {
+    IP_family string `json:"ip_family"`
+    Direction string `json:"direction"`
+    Action string `json:"action"`
+    Priority int `json:"priority"`
+    Protocol string `json:"protocol"`
+    SourceIP string `json:"source_ip"`
+    SourcePort int `json:"source_port"`
+    DestIP string `json:"dest_ip"`
+    DestPort int `json:"dest_port"`
+}
+
+
+
+func enfFirewallRule() *schema.Resource {
+        return &schema.Resource{
+                Create: enfFirewallRuleCreate,
+                Read:   enfFirewallRuleRead,
+                Update: enfFirewallRuleUpdate,
+                Delete: enfFirewallRuleDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "network": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "priority": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Required: true,
+                        },
+                        "protocol": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "direction": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "source_ip": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Default: "*",
+                        },
+                        "source_port": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Optional: true,
+                                Default: 0,
+                        },
+                        "dest_ip": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Optional: true,
+                                Default: "*",
+                        },
+                        "dest_port": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Optional: true,
+                                Default: 0,
+                        },
+                        "action": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "ip_family": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+
+                },
+        }
+}
+
+
+func enfFirewallRuleCreate(d *schema.ResourceData, m interface{}) error {
+
+        domain_url := m.(*EnfClient).DomainURL
+        network := d.Get("network").(string)
+        url := domain_url + "/api/xfw/v1/" + network + "/rule"
+
+        var newRule firewallRuleCreate
+        newRule.IP_family = d.Get("ip_family").(string)
+        newRule.Direction = d.Get("direction").(string)
+        newRule.Action = d.Get("action").(string)
+        newRule.Priority = d.Get("priority").(int)
+        newRule.Protocol = d.Get("protocol").(string)
+
+        jsonData := map[string]interface{}{"ip_family": newRule.IP_family, "direction": newRule.Direction, "action": newRule.Action, "priority": newRule.Priority, "protocol": newRule.Protocol}  
+        jsonValue, _ := json.Marshal(jsonData)
+
+
+        var bearer = "Bearer " + m.(*EnfClient).ApiToken
+        req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+        req.Header.Add("Authorization", bearer)
+        req.Header.Add("content-type", "application/json")
+        req.Header.Add("accept", "application/json")
+
+        client := m.(*EnfClient).HTTPClient
+        response, err := client.Do(req)
+        if err != nil {
+                log.Printf("[ERROR] The HTTP request failed with error %s\n", err)
+                return err        
+        } else {
+            data, _ := ioutil.ReadAll(response.Body)
+            log.Printf("[DEBUG] Response body in enfFirewallRuleCreate: ", string(data))
+
+            var fw_rule firewallRule
+            json.Unmarshal([]byte(data), &fw_rule)
+             d.SetId(fw_rule.Id)
+        }
+
+        return nil
+}
+
+func enfFirewallRuleRead(d *schema.ResourceData, m interface{}) error {
+
+        domain_url := m.(*EnfClient).DomainURL
+        log.Printf("[DEBUG] domain_url from m interface is: ", domain_url)
+        network := d.Get("network").(string)
+        url := domain_url + "/api/xfw/v1/" + network + "/rule"
+
+
+        var bearer = "Bearer " + m.(*EnfClient).ApiToken
+        req, err := http.NewRequest("GET", url, nil)
+        req.Header.Add("Authorization", bearer)
+        req.Header.Add("content-type", "application/json")
+        req.Header.Add("accept", "application/json")
+
+        client := m.(*EnfClient).HTTPClient
+        response, err := client.Do(req)
+        log.Printf("[DEBUG] enfFirewallRuleRead() error is: ", err)
+        if err != nil {
+                log.Printf("[ERROR] The HTTP request failed with error %s\n", err)
+                return err
+        } else {
+            data, _ := ioutil.ReadAll(response.Body)
+        }
+
+        return nil
+}
+
+func enfFirewallRuleUpdate(d *schema.ResourceData, m interface{}) error {
+
+        enfFirewallRuleDelete(d, m)
+        return enfFirewallRuleCreate(d, m)
+}
+
+func enfFirewallRuleDelete(d *schema.ResourceData, m interface{}) error {
+
+        domain_url := m.(*EnfClient).DomainURL
+        network := d.Get("network").(string)
+        id := d.Get("rule_id").(string)
+        url := domain_url + "/api/xfw/v1/" + network + "/rule/" + id
+
+
+        var bearer = "Bearer " + m.(*EnfClient).ApiToken
+        req, err := http.NewRequest("DELETE", url, nil)
+        req.Header.Add("Authorization", bearer)
+        req.Header.Add("content-type", "application/json")
+        req.Header.Add("accept", "application/json")
+
+
+        client := m.(*EnfClient).HTTPClient
+        response, err := client.Do(req)
+        if err != nil {
+                fmt.Printf("The HTTP request failed with error %s\n", err)
+        } else {
+            data, _ := ioutil.ReadAll(response.Body)
+        }
+
+
+        return nil
+}
+
+

--- a/src/enf/resource_enf_group.go
+++ b/src/enf/resource_enf_group.go
@@ -1,0 +1,41 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfGroup() *schema.Resource {
+        return &schema.Resource{
+                Create: enfGroupCreate,
+                Read:   enfGroupRead,
+                Update: enfGroupUpdate,
+                Delete: enfGroupDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "network": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                },
+        }
+}
+
+func enfGroupCreate(d *schema.ResourceData, m interface{}) error {
+        address := d.Get("address").(string)
+        d.SetId(address)
+        return enfGroupRead(d, m)
+}
+
+func enfGroupRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfGroupUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfGroupRead(d, m)
+}
+
+func enfGroupDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+

--- a/src/enf/resource_enf_network.go
+++ b/src/enf/resource_enf_network.go
@@ -1,0 +1,41 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfNetwork() *schema.Resource {
+        return &schema.Resource{
+                Create: enfNetworkCreate,
+                Read:   enfNetworkRead,
+                Update: enfNetworkUpdate,
+                Delete: enfNetworkDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "subnet": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                },
+        }
+}
+
+func enfNetworkCreate(d *schema.ResourceData, m interface{}) error {
+        subnet := d.Get("subnet").(string)
+        d.SetId(subnet)
+        return enfNetworkRead(d, m)
+}
+
+func enfNetworkRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfNetworkUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfNetworkRead(d, m)
+}
+
+func enfNetworkDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+

--- a/src/enf/resource_enf_ratelimit.go
+++ b/src/enf/resource_enf_ratelimit.go
@@ -1,0 +1,61 @@
+package enf
+
+import (
+        "github.com/hashicorp/terraform/helper/schema"
+)
+
+func enfRatelimit() *schema.Resource {
+        return &schema.Resource{
+                Create: enfRatelimitCreate,
+                Read:   enfRatelimitRead,
+                Update: enfRatelimitUpdate,
+                Delete: enfRatelimitDelete,
+
+                Schema: map[string]*schema.Schema{
+                        "limit": &schema.Schema{
+                                Type:     schema.TypeInt,
+                                Required: true,
+                        },
+                        "ipv6": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },  
+                        "network": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },
+                        "api_uri": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        }, 
+                        "filter": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },   
+                        "domain_network": &schema.Schema{
+                                Type:     schema.TypeString,
+                                Required: true,
+                        },                                
+                },
+        }
+}
+
+func enfRatelimitCreate(d *schema.ResourceData, m interface{}) error {
+        subnet := d.Get("subnet").(string)
+        d.SetId(subnet)
+        return enfRatelimitRead(d, m)
+}
+
+func enfRatelimitRead(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+func enfRatelimitUpdate(d *schema.ResourceData, m interface{}) error {
+        return enfRatelimitRead(d, m)
+}
+
+func enfRatelimitDelete(d *schema.ResourceData, m interface{}) error {
+        return nil
+}
+
+


### PR DESCRIPTION
Initial custom Terraform provider enf Firewall rule CRUD operations golang code.

The schema.Schema fields at the top (lines 51-95) are all of the parameters that could potentially be used by an `enf_firewall` resource. Most are required but some are optional and have defaults.
I've defined two structs, `firewallRuleCreate` and `firewallRule`. 
`enfFirewallRuleCreate()` uses the `firewallRuleCreate struct` while doing a POST request, while we receive REST responses using the `firewallRule struct`, because the two have different schema.