### PR TITLE
Fixing build issue with git.apache.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: go
 env:
   global:
     - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
 
 matrix:
   fast_finish: true

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/bflad/tfproviderlint v0.4.0
 	github.com/client9/misspell v0.3.4
-	github.com/golangci/golangci-lint v1.17.1
+	github.com/golangci/golangci-lint v1.18.0
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/terraform v0.12.3
 	github.com/mitchellh/gox v1.0.1 // indirect


### PR DESCRIPTION
Builds for PR's keep failing due to `git.apache.org` downtime. This PR addresses this issue with a solution defined [here](https://github.com/hashicorp/terraform/issues/22664) by setting the `GOPROXY` environment variable.